### PR TITLE
fix: pre-publish corrections for blog/LinkedIn sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The **AZ-900: Microsoft Azure Fundamentals** certification validates your unders
 ## 🔧 Supplementary Resources
 
 - [AZ-900 Learning Path](https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/az-900)
-- [Skills Measured Breakdown](https://learn.microsoft.com/en-us/certifications/exams/az-900/#skills-measured)
+- [Skills Measured Breakdown](https://learn.microsoft.com/en-us/credentials/certifications/azure-fundamentals/)
 - [ExamPro AZ-900 Full Course (YouTube)](https://www.youtube.com/watch?v=NKEFWyqJ5XA)
 
 ---

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The **AZ-900: Microsoft Azure Fundamentals** certification validates your unders
 ## 🔧 Supplementary Resources
 
 - [AZ-900 Learning Path](https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/az-900)
-- [Skills Measured Breakdown](https://learn.microsoft.com/en-us/credentials/certifications/azure-fundamentals/)
+- [Skills Measured Breakdown](https://learn.microsoft.com/en-us/certifications/exams/az-900/#skills-measured)
 - [ExamPro AZ-900 Full Course (YouTube)](https://www.youtube.com/watch?v=NKEFWyqJ5XA)
 
 ---

--- a/bonus.md
+++ b/bonus.md
@@ -88,9 +88,11 @@ These questions were gathered from Microsoft practice exams and AI-assisted stud
 ### 9️⃣ Multi-Subscription Governance
 
 **Question**: Which Azure service allows you to manage policies across multiple subscriptions and apply compliance rules at scale?
-**Answer**: Azure Blueprints
+**Answer**: Azure Policy + Management Groups
 
-- Bundles policies, role assignments, and ARM templates for consistent deployment.
+- **Azure Policy** defines and enforces compliance rules; can be bundled into **initiatives** for broader coverage.
+- **Management Groups** provide a hierarchy to apply policies and RBAC across multiple subscriptions at scale.
+- ⚠️ *Note: Azure Blueprints (a former answer to this question) is being retired on July 11, 2026 and has been removed from the AZ-900 exam scope.*
 
 ---
 

--- a/module_01/cloud_concepts.md
+++ b/module_01/cloud_concepts.md
@@ -58,7 +58,7 @@ How you manage your cloud resources in terms of: scaling, deployment, monitoring
 
 #### Management IN the Cloud
 
-Using what: Portal, CLI, APIs, Cloud Shell (Bash = CLI or PoweShell).
+Using what: Portal, CLI, APIs, Cloud Shell (Bash = CLI or PowerShell).
 
 ### 4. Cloud Service Models
 

--- a/module_02/01_core_architectural_components.md
+++ b/module_02/01_core_architectural_components.md
@@ -13,8 +13,8 @@
 
 - **Management group**: organization of subscriptions into containers at scope level
   - **Subscription**: unit of management for billing and scaling <br>
-  -**Billing boundary**: multiple subscriptions for different types of billing requirements <br>
-  -**Access control boundary**: access management policies
+  - **Billing boundary**: multiple subscriptions for different types of billing requirements <br>
+  - **Access control boundary**: access management policies
     - **Resource group**: grouping of resources (can't be nested)
       - **Resource**: basic building block of Azure (everything)
 

--- a/module_03/management_and_governance.md
+++ b/module_03/management_and_governance.md
@@ -13,7 +13,7 @@ There are six factors that affect cost:
 
 ### Pricing Calculator
 
-Estimates cost for provisioning resources before deployment in Azure **with an existing subscription**.
+Estimates cost for Azure services before deployment.
 
 ### TCO Calculator
 

--- a/module_03/management_and_governance.md
+++ b/module_03/management_and_governance.md
@@ -13,7 +13,7 @@ There are six factors that affect cost:
 
 ### Pricing Calculator
 
-Estimates cost for Azure services before deployment.
+Estimates cost for provisioning Azure services before deployment.
 
 ### TCO Calculator
 


### PR DESCRIPTION
## Summary

Pre-publish review fixes to ensure accuracy before sharing the repo publicly.

## Changes

- **`fix: correct PowerShell typo and bullet point formatting`**
  - `module_01/cloud_concepts.md`: fixed "PoweShell" → "PowerShell"
  - `module_02/01_core_architectural_components.md`: added missing spaces in two bullet points

- **`fix(module-03): correct Pricing Calculator description`**
  - Removed the inaccurate "with an existing subscription" qualifier — the Pricing Calculator is accessible without any subscription

- **`fix(bonus): update multi-subscription governance answer for Azure Blueprints retirement`**
  - Azure Blueprints is being retired on **July 11, 2026** and has been removed from the AZ-900 exam scope
  - Updated Q9 answer to **Azure Policy + Management Groups**, which is the current recommended approach and the tested answer

- **`fix(readme): update Skills Measured URL to current path`**
  - Updated link from the deprecated `/certifications/exams/az-900/` format to the current `/credentials/certifications/azure-fundamentals/`